### PR TITLE
암호 지정시 두 암호가 틀릴경우 암호 지정 첫화면으로 돌아가도록 변경했습니다. 

### DIFF
--- a/LockScreenViewController/JKLLockScreenViewController.h
+++ b/LockScreenViewController/JKLLockScreenViewController.h
@@ -14,6 +14,7 @@ typedef NS_ENUM(NSInteger, LockScreenMode) {
     LockScreenModeNormal = 0,       // [일반 모드]
     LockScreenModeNew,              // [신규 모드]
     LockScreenModeChange,           // [변경 모드]
+    LockScreenModeVerification,     // [확인 모드]
 };
 
 @protocol JKLLockScreenViewControllerDelegate;

--- a/LockScreenViewController/JKLLockScreenViewController.m
+++ b/LockScreenViewController/JKLLockScreenViewController.m
@@ -291,4 +291,19 @@ static const NSTimeInterval LSVShakeAnimationDuration = 0.5f;
     }
 }
 
+#pragma mark - Lock Orientation
+
+- (BOOL)shouldAutorotate {
+    return NO;
+}
+
+- (NSUInteger)supportedInterfaceOrientations {
+    return UIInterfaceOrientationMaskPortrait;
+}
+// pre-iOS 6 support
+- (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation
+{
+    return (toInterfaceOrientation == UIInterfaceOrientationPortrait);
+}
+
 @end

--- a/LockScreenViewController/JKLLockScreenViewController.m
+++ b/LockScreenViewController/JKLLockScreenViewController.m
@@ -16,6 +16,7 @@ static const NSTimeInterval LSVShakeAnimationDuration = 0.5f;
 @interface JKLLockScreenViewController()<JKLLockScreenPincodeViewDelegate> {
     
     NSString * _confirmPincode;
+    LockScreenMode _prevLockScreenMode;
 }
 
 @property (nonatomic, weak) IBOutlet UILabel  * titleLabel;
@@ -32,6 +33,7 @@ static const NSTimeInterval LSVShakeAnimationDuration = 0.5f;
     [super viewDidLoad];
     
     switch (_lockScreenMode) {
+        case LockScreenModeVerification:
         case LockScreenModeNormal: {
             // [일반 모드] Cancel 버튼 감춤
             [_cancelButton setHidden:YES];
@@ -276,11 +278,19 @@ static const NSTimeInterval LSVShakeAnimationDuration = 0.5f;
         else {
             [self lsv_unlockScreenFailure];
         }
-    }
-    else {
+    } else if (_lockScreenMode == LockScreenModeVerification) {
+        // [확인 모드]
+        [self setLockScreenMode:_prevLockScreenMode];
+        if([self lsv_isPincodeValid:pincode]) {
+            [self lsv_unlockScreenSuccessful:pincode];
+        } else {
+            [self lsv_unlockScreenFailure];
+        }
+    } else {
         // [기입 모드], [변경 모드]
         _confirmPincode = pincode;
-        [self setLockScreenMode:LockScreenModeNormal];
+        _prevLockScreenMode = _lockScreenMode;
+        [self setLockScreenMode:LockScreenModeVerification];
         
         // 재입력 타이틀로 전환
         [self lsv_updateTitle:NSLocalizedStringFromTable(@"Pincode Title Confirm",    @"JKLockScreen", nil)


### PR DESCRIPTION
1. 암호화면에서는 오리엔테이션을 막았습니다. 
2. 암호 지정시 두 암호가 틀릴경우 암호 지정 첫화면으로 돌아가도록 변경했습니다.
3. Mode가 New나 Change일 경우에도 작동이 완료되고나면 Delegate 메소드에서 Mode에 접근시 Normal로 변경되어 있어  Mode값을 유지하도록 변경했습니다. 

풀리퀘 받아주시면 감사드리겠습니다. 
